### PR TITLE
Videojs: handle plain HTML5/Flash (no SourceHandler) or Safari built-in HLS + Source-Maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 node_modules
 build/
 temp/
+npm-debug.log
 

--- a/js/adapters/VideoJsAdapter.js
+++ b/js/adapters/VideoJsAdapter.js
@@ -116,7 +116,6 @@ class VideoJsAdapter {
       })
     });
     this.player.on('pause', function() {
-      console.log('pause');
       that.eventCallback(Events.PAUSE, {
         currentTime: this.currentTime()
       })

--- a/js/adapters/VideoJsAdapter.js
+++ b/js/adapters/VideoJsAdapter.js
@@ -73,13 +73,13 @@ class VideoJsAdapter {
   register() {
     const that = this;
     this.player.on('loadedmetadata', function() {
-      const tech       = this.tech({IWillNotUseThisInPlugins: true});
       const streamType = that.getStreamType(this.currentSrc());
       const sources    = that.getStreamSources(this.currentSrc());
+      const mode = that.getVideojsSourceHandlerMode_();
       const info       = {
         isLive     : this.duration() === Infinity,
         version    : videojs.VERSION,
-        type       : tech.sourceHandler_.options_.mode === 'html5' ? 'html5' : 'native',
+        type       : mode,
         duration   : this.duration(),
         streamType,
         autoplay   : this.autoplay(),
@@ -92,13 +92,13 @@ class VideoJsAdapter {
       that.stateMachine.updateMetadata(info);
     });
     this.player.ready(function() {
-      const tech       = this.tech({IWillNotUseThisInPlugins: true});
       const streamType = that.getStreamType(this.currentSrc());
       const sources    = that.getStreamSources(this.currentSrc());
+      const mode = that.getVideojsSourceHandlerMode_();
       const info       = {
         isLive     : false,
         version    : videojs.VERSION,
-        type       : tech.sourceHandler_.options_.mode === 'html5' ? 'html5' : 'native',
+        type       : mode,
         duration   : this.duration(),
         streamType,
         autoplay   : this.autoplay(),

--- a/js/adapters/VideoJsAdapter.js
+++ b/js/adapters/VideoJsAdapter.js
@@ -57,6 +57,19 @@ class VideoJsAdapter {
     }
   }
 
+  /**
+   * @returns {string} 'native' | 'flash' | 'html5'
+   */
+  getVideojsSourceHandlerMode_() {
+    const tech = this.player.tech({IWillNotUseThisInPlugins: true});
+
+    if (!tech.sourceHandler_) {
+      return 'native';
+    } else {
+      return tech.sourceHandler_.options_.mode;
+    }
+  }
+
   register() {
     const that = this;
     this.player.on('loadedmetadata', function() {

--- a/js/adapters/VideoJsAdapter.js
+++ b/js/adapters/VideoJsAdapter.js
@@ -153,7 +153,7 @@ class VideoJsAdapter {
       });
     });
 
-    let analyticsBitrate = -1;
+    let analyticsBitrate;
     let bufferingTimeout;
     let lastTimeupdate   = Date.now();
     let isStalling       = false;

--- a/webpack.config.debug.js
+++ b/webpack.config.debug.js
@@ -15,5 +15,6 @@ module.exports = {
   },
   plugins: [
     new webpack.BannerPlugin(banner)
-  ]
+  ],
+  devtool: 'source-map'
 }


### PR DESCRIPTION
Changes:

* Fixes case where no HLS source-hanlder exists (plain HTML5) or Safari "native" HLS support is used
* Improved "mode" resolving from `tech.sourceHandler_`
* Various code cosmetics
* Source-Maps!

NOTE:

This is done from `v1.5.1` therefore we have conflicts with current `develop` 