### PR TITLE
Added new Metadata change API for Bitmovin 7

### DIFF
--- a/html/bitmovin_old_api.html
+++ b/html/bitmovin_old_api.html
@@ -18,7 +18,7 @@
 
   <title>Bitdash Analytics</title>
 
-  <script type="text/javascript" src="//bitmovin-a.akamaihd.net/bitmovin-player/stable/7.6/bitmovinplayer.js"></script>
+  <script type="text/javascript" src="//bitmovin-a.akamaihd.net/bitmovin-player/stable/7.5/bitmovinplayer.js"></script>
   <script type="text/javascript" src="/build/debug/bitmovinanalytics.min.js"></script>
 </head>
 <body>
@@ -30,11 +30,26 @@
 
     /* global bitmovin */
 
-    var player = bitmovin.player('player');
-    bitmovin.analytics.augment(player);
+    var config = {
+      // Your bitmovin analytics key
+      key: 'e73a3577-d91c-4214-9e6d-938fb936818a',
+      // Your player key (bitmovin, jw, ..) (optional)
+      playerKey: 'a6e31908-550a-4f75-b4bc-a9d89880a733',
+      player: bitmovin.analytics.Players.BITMOVIN,
+      cdnProvider: bitmovin.analytics.CdnProviders.AKAMAI,
+      debug: true,
+      customData1: {
+        json: 'jsonTest',
+        json42: 42
+      },
+      customData2: 'customData2',
+      experimentName: 'bitmovinanalytics-local',
+      videoId: 'Sintel',
+      userId: 'customer#1'
+    };
+    var analytics = bitmovin.analytics(config);
 
-
-    player.setup({
+    var conf = {
       key: 'a6e31908-550a-4f75-b4bc-a9d89880a733',
       playback: {
         autoplay: true,
@@ -47,24 +62,24 @@
           url:  'https://bitdash-a.akamaihd.net/content/MI201109210084_1/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4',
           type: 'video/mp4'
         }]
-      },
-      analytics: {
-        key: 'e73a3577-d91c-4214-9e6d-938fb936818a',
-        experimentName: 'analytics-api',
-        debug: true
       }
-    });
+    };
+    var player = bitmovin.player('player');
+    analytics.register(player);
+    player.setup(conf);
 
-    //document.getElementById('click').onclick = function () {
-    //  analytics.setCustomDataOnce({ customData1: 'after-click' });
-    //};
+    document.getElementById('click').onclick = function () {
+      analytics.setCustomDataOnce({ customData1: 'after-click' });
+    };
+
     document.getElementById('change').onclick = function () {
-      player.load({
-        dash:  'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
-        analytics: {
-          experimentName: 'analytics-switch'
-        }
+      analytics.sourceChange({
+        experimentName: 'analytics-switch'
       });
+      player.load({
+        dash:  'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd'
+      });
+
     };
 
 // window.setTimeout(function () {

--- a/index.html
+++ b/index.html
@@ -44,6 +44,11 @@
             </a>
           </li>
           <li>
+            <a href="html/bitmovin.html">
+              Bitmovin with old Analytics Config API
+            </a>
+          </li>
+          <li>
             <a href="html/hlsjs.html">
               Hls.js
             </a>

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
             </a>
           </li>
           <li>
-            <a href="html/bitmovin.html">
+            <a href="html/bitmovin_old_api.html">
               Bitmovin with old Analytics Config API
             </a>
           </li>

--- a/js/analyticsStateMachines/Bitmovin7AnalyticsStateMachine.js
+++ b/js/analyticsStateMachines/Bitmovin7AnalyticsStateMachine.js
@@ -51,6 +51,10 @@ export class Bitmovin7AnalyticsStateMachine {
       'FINISH_QUALITYCHANGE_REBUFFERING'];
   }
 
+  sourceChange = (config, timestamp) => {
+    this.callEvent(Events.MANUAL_SOURCE_CHANGE, config, timestamp);
+  }
+
   createStateMachine(opts = {}) {
     this.stateMachine = StateMachine.create({
       initial  : this.States.SETUP,
@@ -173,6 +177,7 @@ export class Bitmovin7AnalyticsStateMachine {
         {name: Events.SEEKED, from: this.States.READY, to: this.States.READY},
         {name: Events.SEEKED, from: this.States.STARTUP, to: this.States.STARTUP},
 
+        {name: Events.MANUAL_SOURCE_CHANGE, from: this.getAllStates(), to: this.States.SOURCE_CHANGING },
         {name: Events.SOURCE_UNLOADED, from: this.getAllStates(), to: this.States.SOURCE_CHANGING },
 
         {name: Events.READY, from: this.States.SOURCE_CHANGING, to: this.States.READY },

--- a/js/core/Analytics.js
+++ b/js/core/Analytics.js
@@ -167,7 +167,9 @@ class Analytics {
         this.sample.videoStartupTime = time;
         this.setState(state);
 
-        this.startupTime += time;
+        if (this.startupTime > 0) {
+          this.startupTime += time;
+        }
         this.sample.startupTime = this.startupTime;
         this.sample.autoplay = this.autoplay;
 
@@ -376,6 +378,22 @@ class Analytics {
     const oldConfig = this.config;
     this.setCustomData(values);
     this.setCustomData(oldConfig);
+  }
+
+  sourceChange = (config) => {
+    logger.log('Processing Source Change for Analytics', config);
+    this.sendAnalyticsRequestAndClearValues();
+    this.setupSample();
+    this.startupTime = 0;
+    this.init();
+
+    const newConfig = {
+      ...this.config,
+      ...config
+    };
+    this.setConfigParameters(this.sample, newConfig);
+    
+    this.analyticsStateMachine.sourceChange(Utils.getCurrentTimestamp());
   }
 
   setCustomData = (values) => {

--- a/js/core/BitmovinAnalyticsExport.js
+++ b/js/core/BitmovinAnalyticsExport.js
@@ -18,7 +18,11 @@ analyticsWrapper.augment = (player) => {
   const originalSetup = player.setup;
   let loadedAnalytics;
   player.setup = function () {
-    const retVal = originalSetup.apply(player, arguments);
+    const playerSetupPromise = originalSetup.apply(player, arguments);
+
+    if (arguments.length === 0) {
+      return playerSetupPromise;
+    }
 
     const analyticsConfig = arguments[0].analytics;
     if (analyticsConfig) {
@@ -27,7 +31,7 @@ analyticsWrapper.augment = (player) => {
       // assign the analytics object to the player
       player.analytics = loadedAnalytics;
     }
-    return retVal;
+    return playerSetupPromise;
   };
 
   const originalLoad = player.load;
@@ -36,8 +40,7 @@ analyticsWrapper.augment = (player) => {
     // we reset the analytics and reload with a new config
     loadedAnalytics.sourceChange(analyticsConfig);
 
-    const retVal = originalLoad.apply(player, arguments);
-    return retVal;
+    return originalLoad.apply(player, arguments);
   };
 };
 

--- a/js/core/BitmovinAnalyticsExport.js
+++ b/js/core/BitmovinAnalyticsExport.js
@@ -36,9 +36,11 @@ analyticsWrapper.augment = (player) => {
 
   const originalLoad = player.load;
   player.load = function () {
-    const analyticsConfig = arguments[0].analytics;
-    // we reset the analytics and reload with a new config
-    loadedAnalytics.sourceChange(analyticsConfig);
+    if (arguments.length > 0) {
+      const analyticsConfig = arguments[0].analytics;
+      // we reset the analytics and reload with a new config
+      loadedAnalytics.sourceChange(analyticsConfig);
+    }
 
     return originalLoad.apply(player, arguments);
   };

--- a/js/core/BitmovinAnalyticsExport.js
+++ b/js/core/BitmovinAnalyticsExport.js
@@ -2,23 +2,40 @@ import Analytics from './Analytics';
 import {Players} from '../enums/Players';
 import CdnProviders from '../enums/CDNProviders';
 
-let analytics;
-
-const register = (player, opts = {}) => {
-  analytics.register(player, opts);
-};
-
-const getCurrentImpressionId = () => {
-  return analytics.getCurrentImpressionId();
-};
-
 const analyticsWrapper = (config) => {
-  analytics = new Analytics(config);
+  const analytics = new Analytics(config);
   return {
-    register: register,
-    getCurrentImpressionId: getCurrentImpressionId,
+    register: (player, opts = {}) => { return analytics.register(player, opts); },
+    getCurrentImpressionId: () => { return analytics.getCurrentImpressionId(); },
     setCustomData: analytics.setCustomData,
     setCustomDataOnce: analytics.setCustomDataOnce,
+    sourceChange: (config) => { analytics.sourceChange(config); }
+  };
+};
+
+analyticsWrapper.augment = (player) => {
+  //decorate player to intercept setup
+  const originalSetup = player.setup;
+  let loadedAnalytics;
+  player.setup = function () {
+    const { analytics } = arguments[0];
+    // TODO: Check that the config is actually present
+    const retVal = originalSetup.apply(player, arguments);
+    loadedAnalytics = analyticsWrapper(analytics);
+    loadedAnalytics.register(player);
+    // assign the analytics object to the player
+    player.analytics = loadedAnalytics;
+    return retVal;
+  };
+
+  const originalLoad = player.load;
+  player.load = function () {
+    const { analytics } = arguments[0];
+    // we reset the analytics and reload with a new config
+    loadedAnalytics.sourceChange(analytics);
+
+    const retVal = originalLoad.apply(player, arguments);
+    return retVal;
   };
 };
 

--- a/js/core/BitmovinAnalyticsExport.js
+++ b/js/core/BitmovinAnalyticsExport.js
@@ -18,21 +18,23 @@ analyticsWrapper.augment = (player) => {
   const originalSetup = player.setup;
   let loadedAnalytics;
   player.setup = function () {
-    const { analytics } = arguments[0];
-    // TODO: Check that the config is actually present
     const retVal = originalSetup.apply(player, arguments);
-    loadedAnalytics = analyticsWrapper(analytics);
-    loadedAnalytics.register(player);
-    // assign the analytics object to the player
-    player.analytics = loadedAnalytics;
+
+    const analyticsConfig = arguments[0].analytics;
+    if (analyticsConfig) {
+      loadedAnalytics = analyticsWrapper(analyticsConfig);
+      loadedAnalytics.register(player);
+      // assign the analytics object to the player
+      player.analytics = loadedAnalytics;
+    }
     return retVal;
   };
 
   const originalLoad = player.load;
   player.load = function () {
-    const { analytics } = arguments[0];
+    const analyticsConfig = arguments[0].analytics;
     // we reset the analytics and reload with a new config
-    loadedAnalytics.sourceChange(analytics);
+    loadedAnalytics.sourceChange(analyticsConfig);
 
     const retVal = originalLoad.apply(player, arguments);
     return retVal;

--- a/js/enums/Events.js
+++ b/js/enums/Events.js
@@ -24,7 +24,8 @@ const Events = {
   UNLOAD           : 'unload',
   END              : 'end',
   METADATA_LOADED  : 'metadataLoaded',
-  SOURCE_UNLOADED  : 'sourceUnloaded'
+  SOURCE_UNLOADED  : 'sourceUnloaded',
+  MANUAL_SOURCE_CHANGE: 'manualSourceChangeInitiated'
 };
 
 export default Events;


### PR DESCRIPTION
The idea of this PR is to enable metadata changes when the player loads a new asset.

This PR introduces a new API for analytics where regular player methods (like `.setup` and `.load`) get wrapped/augmented with analytics to more tightly couple the control flow of our analytics intents.

The alternative would have been to have a `analytics.sourceWillChange` method that then needs to wait for a upcoming `player.load()` call etc. This way we know that `player.load` has been called.

For consistency we also moved the analytics configuration into the player config so it's only one config JSON going forward.

Example of such a config:

``` js
    player.setup({
      key: 'a6e31908-550a-4f75-b4bc-a9d89880a733',
      playback: {
        autoplay: true,
        muted: true
      },
      source:    {
        dash: 'http://bitdash-a.akamaihd.net/content/sintel/sintel.mpd',
        hls:  'https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8',
        progressive:  [{
          url:  'https://bitdash-a.akamaihd.net/content/MI201109210084_1/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4',
          type: 'video/mp4'
        }]
      },
      analytics: {
        key: 'e73a3577-d91c-4214-9e6d-938fb936818a',
        experimentName: 'analytics-api'
      }
    });
```

whereas a `player.load` call also needs analytics metadata as a sidecar to the regular source object:

``` js
      player.load({
        dash:  'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
        analytics: {
          experimentName: 'analytics-switch'
        }
      });
```