### PR TITLE
Bugfix/player name autodetect

### DIFF
--- a/html/bitmovin_old_api.html
+++ b/html/bitmovin_old_api.html
@@ -35,7 +35,6 @@
       key: 'e73a3577-d91c-4214-9e6d-938fb936818a',
       // Your player key (bitmovin, jw, ..) (optional)
       playerKey: 'a6e31908-550a-4f75-b4bc-a9d89880a733',
-      player: bitmovin.analytics.Players.BITMOVIN,
       cdnProvider: bitmovin.analytics.CdnProviders.AKAMAI,
       debug: true,
       customData1: {

--- a/html/dashjs.html
+++ b/html/dashjs.html
@@ -36,7 +36,6 @@
     var config = {
       // Your bitmovin analytics key
       key: 'e73a3577-d91c-4214-9e6d-938fb936818a',
-      player: bitmovin.analytics.Players.DASHJS,
       cdnProvider: bitmovin.analytics.CdnProviders.AKAMAI,
       // relevant for development only  - don't set this to true in production
       debug: true,

--- a/html/hlsjs.html
+++ b/html/hlsjs.html
@@ -36,7 +36,6 @@
       key: 'e73a3577-d91c-4214-9e6d-938fb936818a',
       // Your player key (bitmovin, jw, ..) (optional)
       playerKey: 'a6e31908-550a-4f75-b4bc-a9d89880a733',
-      player: bitmovin.analytics.Players.HLSJS,
       cdnProvider: bitmovin.analytics.CdnProviders.AKAMAI,
       debug: true,
       customData1: {

--- a/html/shaka.html
+++ b/html/shaka.html
@@ -37,7 +37,6 @@
       key: 'e73a3577-d91c-4214-9e6d-938fb936818a',
       // Your player key (bitmovin, jw, ..) (optional)
       playerKey: 'a6e31908-550a-4f75-b4bc-a9d89880a733',
-      player: bitmovin.analytics.Players.SHAKA,
       cdnProvider: bitmovin.analytics.CdnProviders.AKAMAI,
       debug: true,
       customData1: {

--- a/html/videojs.html
+++ b/html/videojs.html
@@ -38,7 +38,6 @@
     var config = {
       // Your bitmovin analytics key
       key: 'e73a3577-d91c-4214-9e6d-938fb936818a',
-      player: bitmovin.analytics.Players.VIDEOJS,
       cdnProvider: bitmovin.analytics.CdnProviders.AKAMAI,
       experimentName: 'bitmovinanalytics-local',
       videoId: 'Sintel',

--- a/js/adapters/Bitmovin7Adapter.js
+++ b/js/adapters/Bitmovin7Adapter.js
@@ -1,4 +1,5 @@
 import Events from '../enums/Events';
+import {Players} from '../enums/Players';
 
 class Bitmovin7Adapter {
   constructor(player, eventCallback) {
@@ -6,6 +7,10 @@ class Bitmovin7Adapter {
     this.player = player;
     this.eventCallback = eventCallback;
     this.register();
+  }
+
+  getPlayerName() {
+    return Players.BITMOVIN;
   }
 
   register() {

--- a/js/adapters/BitmovinAdapter.js
+++ b/js/adapters/BitmovinAdapter.js
@@ -1,4 +1,5 @@
 import Events from '../enums/Events';
+import {Players} from '../enums/Players';
 
 class BitmovinAdapter {
   constructor(player, eventCallback) {
@@ -6,6 +7,10 @@ class BitmovinAdapter {
     this.player = player;
     this.eventCallback = eventCallback;
     this.register();
+  }
+
+  getPlayerName() {
+    return Players.BITMOVIN;
   }
 
   register() {

--- a/js/adapters/DashjsAdapter.js
+++ b/js/adapters/DashjsAdapter.js
@@ -2,6 +2,7 @@
 
 import {HTML5Adapter} from './HTML5Adapter';
 import {MIMETypes} from '../enums/MIMETypes';
+import {Players} from '../enums/Players';
 
 export class DashjsAdapter extends HTML5Adapter {
 
@@ -36,6 +37,10 @@ export class DashjsAdapter extends HTML5Adapter {
     this.mediaPlayer = mediaPlayer;
 
     this.setMediaElement(videoEl);
+  }
+
+  getPlayerName() {
+    return Players.DASHJS;
   }
 
   getPlayerVersion() {

--- a/js/adapters/HTML5Adapter.js
+++ b/js/adapters/HTML5Adapter.js
@@ -1,6 +1,7 @@
 import Events from '../enums/Events';
 import {getMIMETypeFromFileExtension} from '../enums/MIMETypes';
 import {getStreamTypeFromMIMEType} from '../enums/StreamTypes';
+import {Players} from '../enums/Players';
 
 const BUFFERING_TIMECHANGED_TIMEOUT = 1000;
 
@@ -107,6 +108,10 @@ export class HTML5Adapter {
     if (mediaElement) {
       this.setMediaElement();
     }
+  }
+
+  getPlayerName() {
+    return Players.HTML5;
   }
 
   /**

--- a/js/adapters/HlsjsAdapter.js
+++ b/js/adapters/HlsjsAdapter.js
@@ -2,6 +2,7 @@
 
 import {HTML5Adapter} from './HTML5Adapter';
 import {MIMETypes} from '../enums/MIMETypes';
+import {Players} from '../enums/Players';
 
 /**
  * @class
@@ -29,6 +30,11 @@ export class HlsjsAdapter extends HTML5Adapter {
     this.resetMedia();
     this.registerHlsEvents();
   }
+
+  getPlayerName() {
+    return Players.HLSJS;
+  }
+
 
   /**
    * Implemented by sub-class to deliver current quality-level info

--- a/js/adapters/ShakaAdapter.js
+++ b/js/adapters/ShakaAdapter.js
@@ -2,6 +2,7 @@
 
 import {HTML5Adapter} from './HTML5Adapter';
 import {MIMETypes} from '../enums/MIMETypes';
+import {Players} from '../enums/Players';
 
 export class ShakaAdapter extends HTML5Adapter {
 
@@ -17,6 +18,10 @@ export class ShakaAdapter extends HTML5Adapter {
      * @member {shaka.Player}
      */
     this.shakaPlayer = shakaPlayer;
+  }
+
+  getPlayerName() {
+    return Players.SHAKA;
   }
 
   getPlayerVersion() {

--- a/js/adapters/VideoJsAdapter.js
+++ b/js/adapters/VideoJsAdapter.js
@@ -1,6 +1,7 @@
 /* global videojs */
 
 import Events from '../enums/Events';
+import {Players} from '../enums/Players';
 
 const BUFFERING_TIMECHANGED_TIMEOUT = 1000;
 
@@ -11,6 +12,10 @@ class VideoJsAdapter {
     this.eventCallback = eventCallback;
     this.stateMachine = stateMachine;
     this.register();
+  }
+
+  getPlayerName() {
+    return Players.VIDEOJS;
   }
 
   getStreamType(url) {

--- a/js/core/Analytics.js
+++ b/js/core/Analytics.js
@@ -446,6 +446,9 @@ class Analytics {
       logger.error('Could not detect player.');
       return;
     }
+    if (!this.sample.player) {
+      this.sample.player = this.adapter.getPlayerName();
+    }
   };
 
   getCurrentImpressionId = () => {

--- a/js/enums/Players.js
+++ b/js/enums/Players.js
@@ -5,5 +5,6 @@ export const Players = {
   VIDEOJS : 'videojs',
   HLSJS   : 'hlsjs',
   SHAKA   : 'shaka',
-  DASHJS  : 'dashjs'
+  DASHJS  : 'dashjs',
+  HTML5   : 'html5'
 };

--- a/js/utils/PlayerDetector.js
+++ b/js/utils/PlayerDetector.js
@@ -41,7 +41,7 @@ class PlayerDetector {
 
   static isHlsjs(player) {
 
-    if (!Hls) {
+    if (!window.Hls) {
       // Hls.js is not defined installed (must be loaded before analytics module)
       return false;
     }


### PR DESCRIPTION
Bug: If the user does not specify a `player` via the `analyticsConfig` the player is reported as `null`/`undefined`.

# Goals
* By default the correct player should be detected
* If the user sets the player via the config it should override the defaults