### PR TITLE
Hotfix/startuptime null

### DIFF
--- a/js/Version.ts
+++ b/js/Version.ts
@@ -1,0 +1,2 @@
+//@ts-ignore
+export const VERSION: string = __VERSION__;

--- a/js/core/Analytics.ts
+++ b/js/core/Analytics.ts
@@ -61,9 +61,6 @@ export class Analytics {
     this.isCastReceiver = false;
     this.isAllowedToSendSamples = false;
     this.samplesQueue = [];
-    this.sample = {
-      pageLoadType: this.pageLoadType
-    };
 
     if (this.config.cast && this.config.cast.receiver) {
       this.isCastReceiver = true;
@@ -82,7 +79,7 @@ export class Analytics {
 
     this.pageLoadType = this.setPageLoadType();
 
-    this.setupSample();
+    this.sample = this.setupSample();
     this.init();
     this.setupStateMachineCallbacks();
   }
@@ -434,7 +431,7 @@ export class Analytics {
     if (this.sample.state) {
       this.sendAnalyticsRequestAndClearValues();
     }
-    this.setupSample();
+    this.sample = this.setupSample();
     this.startupTime = 0;
     this.init();
 
@@ -602,8 +599,9 @@ export class Analytics {
     }
   }
 
-  setupSample() {
-    this.sample = {
+  setupSample() : Sample {
+    return {
+      playerStartupTime: 0,
       pageLoadType: this.pageLoadType,
       domain: Utils.sanitizePath(window.location.hostname),
       path: Utils.sanitizePath(window.location.pathname),

--- a/js/core/Analytics.ts
+++ b/js/core/Analytics.ts
@@ -641,6 +641,7 @@ export class Analytics {
       duration: 0,
       startupTime: 0,
       analyticsVersion: VERSION,
+      pageLoadTime: 0
     };
   }
 

--- a/js/core/Analytics.ts
+++ b/js/core/Analytics.ts
@@ -33,7 +33,6 @@ export class Analytics {
   private droppedSampleFrames: number;
   private licensing: string;
   private startupTime: number;
-  private pageLoadType: PAGE_LOAD_TYPE;
   private autoplay: boolean | undefined;
   private isCastClient: boolean;
   private isCastReceiver: boolean;
@@ -51,7 +50,6 @@ export class Analytics {
     this.analyticsCall = new AnalyticsCall();
     this.castClient = new CastClient();
     this.castReceiver = new CastReceiver();
-    this.pageLoadType = PAGE_LOAD_TYPE.FOREGROUND;
     this.droppedSampleFrames = 0;
     this.licensing = 'waiting';
     this.startupTime = 0;
@@ -77,8 +75,6 @@ export class Analytics {
         }
       });
     }
-
-    this.pageLoadType = this.setPageLoadType();
 
     this.sample = this.setupSample();
     this.init();
@@ -177,7 +173,7 @@ export class Analytics {
         this.setDuration(time);
         this.setState(state);
         this.sample.playerStartupTime = time;
-        this.sample.pageLoadType = this.pageLoadType;
+        this.sample.pageLoadType = this.setPageLoadType();
 
         if (window.performance && window.performance.timing) {
           const loadTime = Utils.getCurrentTimestamp() - window.performance.timing.navigationStart;
@@ -190,7 +186,7 @@ export class Analytics {
 
         this.sendAnalyticsRequestAndClearValues();
 
-        this.sample.pageLoadType = this.pageLoadType;
+        this.sample.pageLoadType = this.setPageLoadType();
         this.sample.pageLoadTime = 0;
       },
 
@@ -611,7 +607,7 @@ export class Analytics {
   setupSample() : Sample {
     return {
       playerStartupTime: 0,
-      pageLoadType: this.pageLoadType,
+      pageLoadType: this.setPageLoadType(),
       domain: Utils.sanitizePath(window.location.hostname),
       path: Utils.sanitizePath(window.location.pathname),
       language: navigator.language || (navigator as any).userLanguage,

--- a/js/core/Analytics.ts
+++ b/js/core/Analytics.ts
@@ -78,7 +78,7 @@ export class Analytics {
       });
     }
 
-    this.setPageLoadType();
+    this.pageLoadType = this.setPageLoadType();
 
     this.setupSample();
     this.init();
@@ -103,13 +103,12 @@ export class Analytics {
     this.setConfigParameters(sample, config);
   }
 
-  setPageLoadType() {
-    window.setTimeout(() => {
-      //@ts-ignore
-      if (document[Utils.getHiddenProp()] === true) {
-        this.pageLoadType = PAGE_LOAD_TYPE.BACKGROUND;
-      }
-    }, Analytics.PAGE_LOAD_TYPE_TIMEOUT);
+  setPageLoadType() : PAGE_LOAD_TYPE {
+    //@ts-ignore
+    if (document[Utils.getHiddenProp()] === true) {
+      return PAGE_LOAD_TYPE.BACKGROUND;
+    }
+    return PAGE_LOAD_TYPE.FOREGROUND
   }
 
   init() {

--- a/js/core/Analytics.ts
+++ b/js/core/Analytics.ts
@@ -173,7 +173,6 @@ export class Analytics {
         this.setDuration(time);
         this.setState(state);
         this.sample.playerStartupTime = time;
-        this.sample.pageLoadType = this.setPageLoadType();
 
         if (window.performance && window.performance.timing) {
           const loadTime = Utils.getCurrentTimestamp() - window.performance.timing.navigationStart;
@@ -186,7 +185,6 @@ export class Analytics {
 
         this.sendAnalyticsRequestAndClearValues();
 
-        this.sample.pageLoadType = this.setPageLoadType();
         this.sample.pageLoadTime = 0;
       },
 

--- a/js/core/Analytics.ts
+++ b/js/core/Analytics.ts
@@ -50,11 +50,10 @@ export class Analytics {
     this.analyticsCall = new AnalyticsCall();
     this.castClient = new CastClient();
     this.castReceiver = new CastReceiver();
-    this.sample = {};
+    this.pageLoadType = PAGE_LOAD_TYPE.FOREGROUND;
     this.droppedSampleFrames = 0;
     this.licensing = 'waiting';
     this.startupTime = 0;
-    this.pageLoadType = PAGE_LOAD_TYPE.FOREGROUND;
 
     this.autoplay = undefined;
 
@@ -62,6 +61,9 @@ export class Analytics {
     this.isCastReceiver = false;
     this.isAllowedToSendSamples = false;
     this.samplesQueue = [];
+    this.sample = {
+      pageLoadType: this.pageLoadType
+    };
 
     if (this.config.cast && this.config.cast.receiver) {
       this.isCastReceiver = true;
@@ -602,6 +604,7 @@ export class Analytics {
 
   setupSample() {
     this.sample = {
+      pageLoadType: this.pageLoadType,
       domain: Utils.sanitizePath(window.location.hostname),
       path: Utils.sanitizePath(window.location.pathname),
       language: navigator.language || (navigator as any).userLanguage,
@@ -736,7 +739,6 @@ export class Analytics {
 
     this.sample.duration = 0;
     this.sample.droppedFrames = 0;
-    this.sample.pageLoadType = 0;
 
     this.sample.drmType = undefined;
     this.sample.drmLoadTime = undefined;

--- a/js/core/Analytics.ts
+++ b/js/core/Analytics.ts
@@ -14,6 +14,7 @@ import {AnalyticsStateMachine} from '../types/AnalyticsStateMachine';
 import {AnalyicsConfig} from '../types/AnalyticsConfig';
 import {Player} from '../enums/Player';
 import {CastClientConfig} from '../types/CastClientConfig';
+import {VERSION} from '../Version';
 
 enum PAGE_LOAD_TYPE {
   FOREGROUND = 1,
@@ -633,8 +634,7 @@ export class Analytics {
       startupTime: 0,
       version: this.sample.version,
       player: this.sample.player,
-      //@ts-ignore
-      analyticsVersion: __VERSION__,
+      analyticsVersion: VERSION,
     };
   }
 

--- a/js/core/Analytics.ts
+++ b/js/core/Analytics.ts
@@ -432,7 +432,15 @@ export class Analytics {
     if (this.sample.state) {
       this.sendAnalyticsRequestAndClearValues();
     }
-    this.sample = this.setupSample();
+
+    // Carry over the player and version from the old sample (was detected during register)
+    const {player, version} = this.sample;
+    this.sample = {
+      ...this.setupSample(),
+      player,
+      version
+    };
+
     this.startupTime = 0;
     this.init();
 
@@ -632,8 +640,6 @@ export class Analytics {
       videoStartupTime: 0,
       duration: 0,
       startupTime: 0,
-      version: this.sample.version,
-      player: this.sample.player,
       analyticsVersion: VERSION,
     };
   }

--- a/js/types/Sample.ts
+++ b/js/types/Sample.ts
@@ -28,7 +28,7 @@ export interface Sample {
   duration?: number;
   startupTime?: number;
   analyticsVersion?: any;
-  playerStartupTime?: number;
+  playerStartupTime: number;
   pageLoadType: number;
   streamFormat?: string;
   isMuted?: boolean;

--- a/js/types/Sample.ts
+++ b/js/types/Sample.ts
@@ -29,7 +29,7 @@ export interface Sample {
   startupTime?: number;
   analyticsVersion?: any;
   playerStartupTime?: number;
-  pageLoadType?: number;
+  pageLoadType: number;
   streamFormat?: string;
   isMuted?: boolean;
   progUrl?: string;

--- a/js/types/Sample.ts
+++ b/js/types/Sample.ts
@@ -44,7 +44,7 @@ export interface Sample {
   errorMessage?: any;
   errorCode?: any;
   autoplay?: any;
-  pageLoadTime?: number;
+  pageLoadTime: number;
   experimentName?: any;
   customData1?: any;
   customData2?: any;


### PR DESCRIPTION
Problem 1: 
When doing a sourceChange the `pageLoadType` is always 0.
Source: The `pageLoadType` was reset to 0 for all subsequent samples of one session. This was not taken into account when the source is changed so all subsequent videos are also `pageLoadType:0`

This causes some issues with the Dashboard as the dashboard only looks at `videoStartupTime` where the pageLoadType is 1

Problem 2:
If the `playerStartupTime` was NULL it could not be summed up with `videoStartupTime` so `startupTime` was not set.
This only impacted impressions after a sourceChange, but these ended up in the backend with `NULL` instead of 0 for a `playerStartupTime`. The actual behavior was still correct and no data is impacted except if a query was done for `.filter('playerStartupTime', 'EQ', 0)` but for consistency reasons it should be 0 not NULL. (Can be retroactively changed on the backend)
